### PR TITLE
Add audio transcription popup

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,6 +8,7 @@
     "48": "icon48.png",
     "128": "icon128.png"
   },
+  "permissions": ["microphone", "windows"],
   "action": {
     "default_title": "Clique para abrir",
     "default_popup": "index.html"

--- a/src/App.css
+++ b/src/App.css
@@ -24,3 +24,10 @@ button {
 button:hover {
   border-color: #646cff;
 }
+
+.transcript {
+  margin-top: 1rem;
+  font-size: 14px;
+  text-align: left;
+  white-space: pre-wrap;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,39 @@
-import { useState } from "react";
-import "./App.css"; // Vamos criar este arquivo
+import { useEffect, useState } from 'react';
+import './App.css';
+
+// Declaração simples para o objeto chrome da API de extensões
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const chrome: any;
 
 function App() {
-  const [count, setCount] = useState(0);
+  const [transcript, setTranscript] = useState('');
+
+  const startTranscription = () => {
+    chrome.windows.create({
+      url: chrome.runtime.getURL('transcriber.html'),
+      type: 'popup',
+      focused: false,
+      width: 300,
+      height: 200,
+    });
+  };
+
+  useEffect(() => {
+    const handler = (message: { type: string; text: string }) => {
+      if (message.type === 'transcription') {
+        setTranscript(message.text);
+      }
+    };
+    chrome.runtime.onMessage.addListener(handler);
+    return () => chrome.runtime.onMessage.removeListener(handler);
+  }, []);
 
   return (
     <div className="App">
       <header className="App-header">
-        <h1>Popup da Extensão</h1>
-        <p>Você clicou {count} vezes</p>
-        <button onClick={() => setCount((count) => count + 1)}>
-          Clique aqui
-        </button>
+        <h1>Transcrição em Tempo Real</h1>
+        <button onClick={startTranscription}>Transcrever áudio</button>
+        <p className="transcript">{transcript}</p>
       </header>
     </div>
   );

--- a/src/transcriber.ts
+++ b/src/transcriber.ts
@@ -1,0 +1,24 @@
+// Página de transcrição que captura áudio e envia o texto ao popup
+// Declaração simples para evitar erros de tipos
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const chrome: any;
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+const SpeechRecognition: any = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+
+if (SpeechRecognition) {
+  const recognition = new SpeechRecognition();
+  recognition.continuous = true;
+  recognition.interimResults = true;
+
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  recognition.onresult = (event: any) => {
+    let transcript = '';
+    for (let i = event.resultIndex; i < event.results.length; i++) {
+      transcript += event.results[i][0].transcript;
+    }
+    // Envia a transcrição parcial para o popup
+    chrome.runtime.sendMessage({ type: 'transcription', text: transcript });
+  };
+
+  recognition.start();
+}

--- a/transcriber.html
+++ b/transcriber.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Transcrição</title>
+  </head>
+  <body>
+    <script type="module" src="/src/transcriber.ts"></script>
+  </body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      input: {
+        main: 'index.html',
+        transcriber: 'transcriber.html',
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- enable microphone and window permissions
- open a background transcription window that streams text to the popup
- wire Vite to build the new transcriber page

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689205041a40832aa559864e3328810f