### PR TITLE
Fix minimization error when opening transcriber window

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,14 +9,22 @@ function App() {
   const [transcript, setTranscript] = useState("");
 
   const startConsultation = () => {
-    chrome.windows.create({
-      url: chrome.runtime.getURL("transcriber.html"),
-      type: "popup",
-      focused: false,
-      state: "minimized",
-      width: 300,
-      height: 200,
-    });
+    chrome.windows
+      .create({
+        url: chrome.runtime.getURL("transcriber.html"),
+        type: "popup",
+        focused: false,
+        width: 300,
+        height: 200,
+      })
+      .then((createdWindow: { id?: number }) => {
+        if (createdWindow?.id !== undefined) {
+          chrome.windows.update(createdWindow.id, { state: "minimized" });
+        }
+      })
+      .catch((error: unknown) => {
+        console.error("Window creation error:", error);
+      });
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid "Invalid value for state" by creating popup without a state and minimizing via `chrome.windows.update`
- log any window creation errors for easier debugging

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899fcc33788832a898f44b57354945f