### PR TITLE
fix: remove unsafe eval bundle usage

### DIFF
--- a/src/transcriber.ts
+++ b/src/transcriber.ts
@@ -1,4 +1,6 @@
-import { SofyaTranscriber } from "sofya.transcription";
+// Importa diretamente a implementação sem usar o bundle que contém "eval"
+// para evitar violações da Content Security Policy em extensões MV3.
+import { SofyaTranscriber } from "sofya.transcription/dist/services/transcription/SofyaTranscriber";
 
 // Declaração simples para evitar erros de tipos
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary
- avoid using sofya.transcription bundle built with eval to comply with MV3 CSP

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a00c69944832ab1cb0031b1d8aa8e