### PR TITLE
fix: add missing eventemitter3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "sofya.transcription": "^0.0.16"
+    "sofya.transcription": "^0.0.16",
+    "eventemitter3": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",


### PR DESCRIPTION
## Summary
- install eventemitter3 library required by sofya.transcription

## Testing
- `pnpm lint`

> **Note**
> Installation of dependencies (pnpm add) failed with `ERR_PNPM_FETCH_403` due to registry access restrictions, so lockfile is unchanged.

------
https://chatgpt.com/codex/tasks/task_e_689ac8a71c1c832ab328ee9cd3e3977e