### PR TITLE
feat: integrate chrome extension transcriber

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "sofya.transcription": "^0.0.16",
+    "sofya.transcription.extension.chrome": "^0.0.1",
     "eventemitter3": "^5.0.1"
   },
   "devDependencies": {

--- a/src/transcriber.ts
+++ b/src/transcriber.ts
@@ -1,38 +1,17 @@
-// Importa diretamente a implementação sem usar o bundle que contém "eval"
-// para evitar violações da Content Security Policy em extensões MV3.
-import { SofyaTranscriber } from "sofya.transcription/dist/services/transcription/SofyaTranscriber";
+import { ChromeExtensionTranscriber } from "sofya.transcription.extension.chrome";
 
-// Declaração simples para evitar erros de tipos
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const chrome: any;
 
-const transcriber = new SofyaTranscriber({
+const transcriber = new ChromeExtensionTranscriber({
   apiKey: "kRx7FgVM11HdZqp63sNtY56UwCcXvlzrLm8bJeF",
-  config: {
-    language: "pt-BR",
+  language: "pt-BR",
+  onTranscription: (text: string) => {
+    chrome.runtime.sendMessage({ type: "transcription", text });
+  },
+  onError: (error: unknown) => {
+    console.error("Transcription error:", error);
   },
 });
 
-transcriber.on("recognizing", (text: string) => {
-  chrome.runtime.sendMessage({ type: "transcription", text });
-});
-
-transcriber.on("recognized", (text: string) => {
-  chrome.runtime.sendMessage({ type: "transcription", text });
-});
-
-transcriber.on("error", (error: unknown) => {
-  console.error("Transcription error:", error);
-});
-
-transcriber.on("ready", () => {
-  navigator.mediaDevices
-    .getUserMedia({ audio: true })
-    .then((mediaStream) => {
-      transcriber.startTranscription(mediaStream);
-    })
-    .catch((error: unknown) => {
-      console.error("Error accessing microphone:", error);
-    });
-});
-
+transcriber.start();


### PR DESCRIPTION
## Summary
- use `sofya.transcription.extension.chrome` for transcription

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm lint`
- `pnpm build` *(fails: Cannot find module 'sofya.transcription.extension.chrome')*


------
https://chatgpt.com/codex/tasks/task_e_689b41a65a54832abc10688dedf584f1